### PR TITLE
Disable supermaven inline completion plugin

### DIFF
--- a/lua/plugins/supermaven-plugin.lua
+++ b/lua/plugins/supermaven-plugin.lua
@@ -1,12 +1,12 @@
 return {
-  "supermaven-inc/supermaven-nvim",
-  config = function()
-    require("supermaven-nvim").setup({
-      keymaps = {
-        accept_word = "<C-RIGHT>",
-        accept_suggestion = "<C-j>"
-      },
-      disable_inline_completion = false,
-    })
-  end,
+  -- "supermaven-inc/supermaven-nvim",
+  -- config = function()
+  --   require("supermaven-nvim").setup({
+  --     keymaps = {
+  --       accept_word = "<C-RIGHT>",
+  --       accept_suggestion = "<C-j>"
+  --     },
+  --     disable_inline_completion = false,
+  --   })
+  -- end,
 }


### PR DESCRIPTION
## Summary
- Comments out the supermaven-nvim plugin configuration to disable inline AI completion

## Test plan
- [ ] Verify neovim starts without errors
- [ ] Confirm no supermaven inline completions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)